### PR TITLE
Allow save icon only when icon was selected

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -24,6 +24,7 @@ function attachListeners() {
     .on('click', '.icon-item', function() {
       $('.icon-item').not(this).removeClass('selected');
       $(this).toggleClass('selected');
+      Fliplet.Widget.emit('icon-clicked', {isSelected: !!$('.icon-item.selected').data('icon-id')});
     })
     .on('click', '.clear-search', function() {
       $('.search-field').val('');
@@ -84,6 +85,7 @@ function init() {
   getAllIconsInArray();
   attachListeners();
   renderFullList(fontAwesomeIcons);
+  Fliplet.Widget.emit('icon-clicked', {isSelected: !!$('.icon-item.selected').data('icon-id')});
 }
 
 Fliplet.Widget.onSaveRequest(function() {

--- a/js/interface.js
+++ b/js/interface.js
@@ -24,7 +24,7 @@ function attachListeners() {
     .on('click', '.icon-item', function() {
       $('.icon-item').not(this).removeClass('selected');
       $(this).toggleClass('selected');
-      Fliplet.Widget.emit('icon-clicked', {isSelected: !!$('.icon-item.selected').data('icon-id')});
+      Fliplet.Widget.emit('icon-clicked', { isSelected: !!$('.icon-item.selected').data('icon-id') });
     })
     .on('click', '.clear-search', function() {
       $('.search-field').val('');


### PR DESCRIPTION
@sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/5651

## Description
Allow saving icon only when the icon was selected

## Screenshots/screencasts
https://share.getcloudapp.com/RBudgb4J

## Backward compatibility

This change is fully backward compatible.

## Notes
Works with this [PR](https://github.com/Fliplet/fliplet-widget-list-small-thumbs/pull/43).

## Reviewers 
@upplabs-alex-levchenko @MaksymShokin